### PR TITLE
Add Sidi Mohamed Ben AbdellahUniversity

### DIFF
--- a/lib/domains/ma/ac/usmba.txt
+++ b/lib/domains/ma/ac/usmba.txt
@@ -1,0 +1,2 @@
+Sidi Mohamed ben Abdellah
+Sidi Mohamed ben Abdellah University


### PR DESCRIPTION
Adding domain for Sid Mohamed Ben Abdellah University (.usmba.ac.ma)